### PR TITLE
Add support for mbed TLS 2.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -352,16 +352,41 @@ AC_ARG_VAR([POLARSSL_CFLAGS], [C compiler flags for PolarSSL])
 AC_ARG_VAR([POLARSSL_LIBS], [linker flags for PolarSSL])
 if test -z "${POLARSSL_LIBS}"; then
 	AC_CHECK_LIB(
-		[polarssl],
-		[x509parse_crt],
+		[mbedtls],
+		[mbedtls_x509_crt_parse],
 		[
-			POLARSSL_LIBS="-lpolarssl"
+			POLARSSL_LIBS="-lmbedtls -lmbedx509 -lmbedcrypto"
 			have_polarssl="yes"
 		],
-		[have_polarssl="no"]
+		[AC_CHECK_LIB(
+			[polarssl],
+			[x509_crt_parse],
+			[
+				POLARSSL_LIBS="-lpolarssl"
+				have_polarssl="yes"
+			],
+			[have_polarssl="no"]
+		)]
 	)
 else
 	have_polarssl="yes"
+fi
+
+if test "${have_polarssl}" = "yes"; then
+	old_CFLAGS="${CFLAGS}"
+	old_CPPFLAGS="${CPPFLAGS}"
+	CFLAGS="${CFLAGS} ${POLARSSL_CFLAGS}"
+	CPPFLAGS="${CPPFLAGS} ${POLARSSL_CFLAGS}"
+	AC_CHECK_HEADER(
+		[mbedtls/version.h],
+		[
+			have_mbedtls="yes"
+			AC_DEFINE([HAVE_LIBMBEDTLS], [1], [Using mbed TLS 2.x])
+		],
+		[have_mbedtls="no"]
+	)
+	CFLAGS="${old_CFLAGS}"
+	CPPFLAGS="${old_CPPFLAGS}"
 fi
 
 # Checks for header files.


### PR DESCRIPTION
Adds support for mbed TLS 2.x, retains support for polarssl 1.3, removes
support for (no longer upstream maintained) polarssl 1.2.  Supporting all
three would require too many hacks.

(The mbedtls/compat-1.3.h file is currently broken, I have a pull request
for mbedtls pending to fix that:
https://github.com/ARMmbed/mbedtls/pull/356)

Signed-off-by: Steffan Karger <steffan@karger.me>