### PR TITLE
openssl: support OpenSSL 1.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -404,7 +404,7 @@ if test "${enable_pedantic}" = "yes"; then
 fi
 
 if test "${enable_strict}" = "yes"; then
-	CFLAGS="${CFLAGS} -Wall -Wextra -Wpointer-arith -Wsign-compare -Wno-unused-parameter -Wno-unused-function -Wno-variadic-macros"
+	CFLAGS="${CFLAGS} -Wall -Wextra -Wpointer-arith -Wsign-compare -Wno-unused-parameter -Wno-unused-function -Wno-variadic-macros -Wno-long-long"
 fi
 
 # Checks for header files.

--- a/configure.ac
+++ b/configure.ac
@@ -398,11 +398,21 @@ if test -n "${MBEDTLS_CFLAGS}" -a "${have_mbedtls}" = "yes"; then
 	CFLAGS="${old_CFLAGS}"
 fi
 
+if test "${enable_pedantic}" = "yes"; then
+	enable_strict="yes"
+	CFLAGS="${CFLAGS} -ansi -pedantic -D__STRICT_ANSI__ -D_ISOC99_SOURCE -D_DEFAULT_SOURCE"
+fi
+
+if test "${enable_strict}" = "yes"; then
+	CFLAGS="${CFLAGS} -Wall -Wextra -Wpointer-arith -Wsign-compare -Wno-unused-parameter -Wno-unused-function -Wno-variadic-macros"
+fi
+
 # Checks for header files.
 AC_HEADER_STDC
 AX_CPP_VARARG_MACRO_ISO
 AX_CPP_VARARG_MACRO_GCC
 AC_C_CONST
+AC_C_INLINE
 AC_C_VOLATILE
 AC_TYPE_OFF_T
 AC_TYPE_PID_T
@@ -509,15 +519,6 @@ if test "${enable_crypto_engine_mbedtls}" = "yes"; then
 	fi
 else
 	AC_MSG_RESULT([no])
-fi
-
-if test "${enable_pedantic}" = "yes"; then
-	enable_strict="yes"
-	CFLAGS="${CFLAGS} -ansi -pedantic -D__STRICT_ANSI__ -D_ISOC99_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE"
-fi
-
-if test "${enable_strict}" = "yes"; then
-	CFLAGS="${CFLAGS} -Wall -Wextra -Wpointer-arith -Wsign-compare -Wno-unused-parameter -Wno-unused-function"
 fi
 
 if test "${enable_threading}" != "yes" -a "${enable_slotevent}" = "yes"; then

--- a/lib/_pkcs11h-crypto-mbedtls.c
+++ b/lib/_pkcs11h-crypto-mbedtls.c
@@ -176,7 +176,7 @@ __pkcs11h_crypto_mbedtls_certificate_is_issuer (
 ) {
 	x509_crt x509_issuer;
 	x509_crt x509_cert;
-	int verify_flags = 0;
+	uint32_t verify_flags = 0;
 
 	PKCS11H_BOOL is_issuer = FALSE;
 


### PR DESCRIPTION
This PR makes it possible to build pkcs11-helper with the new OpenSSL 1.1.0 API, as well as 1.0.x.
