### PR TITLE
Fix __pkcs11_crypto_mbedtls_cerificate_is_issuer()

### DIFF
--- a/lib/_pkcs11h-crypto-mbedtls.c
+++ b/lib/_pkcs11h-crypto-mbedtls.c
@@ -197,7 +197,9 @@ __pkcs11h_crypto_mbedtls_certificate_is_issuer (
 	}
 
 	if ( 0 == x509_crt_verify(&x509_cert, &x509_issuer, NULL, NULL,
-		&verify_flags, NULL, NULL ))
+		&verify_flags, NULL, NULL )) {
+		is_issuer = TRUE;
+	}
 
 cleanup:
 	x509_crt_free(&x509_cert);


### PR DESCRIPTION
This function would leak memory if cert_blob was indeed issued by
issuer_blob, instead of reporting true.

Signed-off-by: Steffan Karger <steffan@karger.me>