### PR TITLE
Don't use $Id$ expansion in the ChangeLog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-ChangeLog ident

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,6 @@
 pkcs11-helper
 Copyright (c) 2005-2011 Alon Bar-Lev <alon.barlev@gmail.com>
 
-$Id$
-
 ????-??-?? - Version 1.21
 
  * mbedtls: fix missing logic if issur certificate, thanks to Steffan Karger


### PR DESCRIPTION
$Id$ expansion makes it difficult to package pkcs11-helper in debian with
git-buildpackage.