### PR TITLE
Build-fixes on LEDE

### DIFF
--- a/include/pkcs11-helper-1.0/pkcs11h-openssl.h
+++ b/include/pkcs11-helper-1.0/pkcs11h-openssl.h
@@ -68,6 +68,15 @@
 #define __PKCS11H_HELPER_H
 
 #include <openssl/x509.h>
+#ifndef OPENSSL_NO_RSA
+#include <openssl/rsa.h>
+#endif
+#ifndef OPENSSL_NO_DSA
+#include <openssl/dsa.h>
+#endif
+#ifndef OPENSSL_NO_DH
+#include <openssl/dh.h>
+#endif
 #include <pkcs11-helper-1.0/pkcs11h-core.h>
 #include <pkcs11-helper-1.0/pkcs11h-certificate.h>
 

--- a/lib/pkcs11h-openssl.c
+++ b/lib/pkcs11h-openssl.c
@@ -95,7 +95,8 @@ struct pkcs11h_openssl_session_s {
 	pkcs11h_hook_openssl_cleanup_t cleanup_hook;
 };
 
-#if OPENSSL_VERSION_NUMBER < 0x10100001L
+#if OPENSSL_VERSION_NUMBER < 0x100020CFL
+#ifndef OPENSSL_NO_RSA
 static RSA_METHOD *
 RSA_meth_dup (const RSA_METHOD *meth)
 {
@@ -170,7 +171,9 @@ RSA_meth_set_priv_dec(
 	meth->rsa_priv_dec = priv_dec;
 	return 1;
 }
+#endif
 
+#ifndef OPENSSL_NO_DSA
 static DSA_METHOD *
 DSA_meth_dup (const DSA_METHOD *meth)
 {
@@ -224,6 +227,7 @@ DSA_SIG_set0 (DSA_SIG *sig, BIGNUM *r, BIGNUM *s)
     sig->s = s;
     return 1;
 }
+#endif
 #endif
 
 static struct {


### PR DESCRIPTION
Some time in the OpenSSL 1.1 timeline, RSA_METHOD and DSA_METHOD became
opaque, while there are some scattered calls to sizeof(RSA_METHOD) and
attempts to read, e.g. ->name from these.  This appears to have been
backported at least to 1.0.2l and possibly earlier.  I "fixed" this by
changing the version test within `pkcs11h-openssl.c` from `10100001` to
`100020CF`; I have no idea if this is the right fix.

If deprecated APIs are disabled, openssl/x509.h no longer recursively
includes rsa.h, dsa.h, or dh.h.  This is easily fixed by adding the
appropriate includes, guarded by the appropriate ifndefs.