### PR TITLE
core: bypass atfork when within C_Initialize or hook

### DIFF
--- a/lib/_pkcs11h-core.h
+++ b/lib/_pkcs11h-core.h
@@ -185,6 +185,7 @@ struct _pkcs11h_data_s {
 		_pkcs11h_mutex_t session;
 		_pkcs11h_mutex_t cache;
 	} mutexes;
+	PKCS11H_BOOL bypass_atfork;
 #endif
 #if !defined(_WIN32)
 	PKCS11H_BOOL safefork;

--- a/tests/test-basic/test-basic.c
+++ b/tests/test-basic/test-basic.c
@@ -42,6 +42,7 @@ int main () {
 	}
 
 	pkcs11h_setLogLevel (TEST_LOG_LEVEL);
+	pkcs11h_setForkMode(TRUE);
 
 	printf ("Adding provider '%s'\n", TEST_PROVIDER);
 


### PR DESCRIPTION
OpenSC provide performs fork() when C_Initialize, and hooks make fork for a
utility.

This attempts to perform unsafe fork and then terminate library to minimize
affects on child processes.