### PR TITLE
build: msvc: add proper checksum into PE header

### DIFF
--- a/lib/Makefile.w32-vc
+++ b/lib/Makefile.w32-vc
@@ -82,7 +82,7 @@ CFLAGS=$(CFLAGS) -DNDEBUG
 
 LINK32=link.exe
 LIB32=lib.exe
-LINK32_FLAGS=/nologo /subsystem:windows /dll /incremental:no
+LINK32_FLAGS=/nologo /subsystem:windows /dll /incremental:no /release
 LIB32_FLAGS=/nologo
 
 HEADERS = \


### PR DESCRIPTION
The MSVC does not set the binary checksum in the PE header by default. The checksum may be used by Microsoft Installer to compare binaries when a user invokes package repair.