### PR TITLE
nmake: openssl 1.1.1 support

### DIFF
--- a/config-w32-vc.h.in
+++ b/config-w32-vc.h.in
@@ -185,3 +185,36 @@
 #if _MSC_VER >= 1400
 #define HAVE_CPP_VARARG_MACRO_ISO 1
 #endif
+
+/* Define to 1 if you have the `RSA_meth_dup' function. */
+#define HAVE_RSA_METH_DUP 1
+
+/* Define to 1 if you have the `RSA_meth_free' function. */
+#define HAVE_RSA_METH_FREE 1
+
+/* Define to 1 if you have the `RSA_meth_set1_name' function. */
+#define HAVE_RSA_METH_SET1_NAME 1
+
+/* Define to 1 if you have the `RSA_meth_set_flags' function. */
+#define HAVE_RSA_METH_SET_FLAGS 1
+
+/* Define to 1 if you have the `RSA_meth_set_priv_dec' function. */
+#define HAVE_RSA_METH_SET_PRIV_DEC 1
+
+/* Define to 1 if you have the `RSA_meth_set_priv_enc' function. */
+#define HAVE_RSA_METH_SET_PRIV_ENC 1
+
+/* Define to 1 if you have the `DSA_meth_dup' function. */
+#define HAVE_DSA_METH_DUP 1
+
+/* Define to 1 if you have the `DSA_meth_free' function. */
+#define HAVE_DSA_METH_FREE 1
+
+/* Define to 1 if you have the `DSA_meth_set1_name' function. */
+#define HAVE_DSA_METH_SET1_NAME 1
+
+/* Define to 1 if you have the `DSA_meth_set_sign' function. */
+#define HAVE_DSA_METH_SET_SIGN 1
+
+/* Define to 1 if you have the `DSA_SIG_set0' function. */
+#define HAVE_DSA_SIG_SET0 1

--- a/lib/Makefile.w32-vc
+++ b/lib/Makefile.w32-vc
@@ -60,9 +60,9 @@ OPENSSL_HOME = ..\..\openssl-0.9.8a
 !endif
 
 !ifdef OPENSSL
-OPENSSL_STATIC = libeay32.lib
+OPENSSL_STATIC = libcrypto.lib
 #OPENSSL_STATIC = libeay32sd.lib
-OPENSSL_DYNAMIC = libeay32.lib
+OPENSSL_DYNAMIC = libcrypto.lib
 #OPENSSL_DYNAMIC = libeay32d.lib
 
 OPENSSL_INC=$(OPENSSL_HOME)\include


### PR DESCRIPTION
Starting from version 1.1.1, OpenSSL includes routines
like RSA_meth_xxx and DSA_meth_xxx. pkcs11-helper includes
implementation of those routines. That code is compiled if
they're missing from OpenSSL.

nmake build uses pre-generated config-w32-vc.h, which lacks
defines which indicate that OpenSSL includes above routines,
which causes pkcs11's own implementaion to be compiled. However,
pkcs11-helper implementation is not compatible with OpenSSL 1.1.1 -
for example, it takes size of opaque struct RSA_METHOD, which
has become internal in OpenSSL.

This adds necessary defines to config header used by nmake build
so that pkcs11-helper code, which is not compatible with OpenSSL 1.1.1,
is not compiled.

Also libeay is changed to libcrypto.

Signed-off-by: Lev Stipakov <lev@openvpn.net>