### PR TITLE
pkcs11.h: fix build with latest libnss

### DIFF
--- a/include/pkcs11-helper-1.0/pkcs11.h
+++ b/include/pkcs11-helper-1.0/pkcs11.h
@@ -1716,6 +1716,13 @@ typedef struct ck_function_list_3_0 **CK_FUNCTION_LIST_3_0_PTR_PTR;
 typedef struct ck_c_initialize_args CK_C_INITIALIZE_ARGS;
 typedef struct ck_c_initialize_args *CK_C_INITIALIZE_ARGS_PTR;
 
+/* FIPS Indicator Interface. This may move to the normal PKCS #11 table
+ * in the future. For now it's called "Vendor NSS FIPS Interface" */
+typedef CK_RV (*CK_NSS_GetFIPSStatus)(CK_SESSION_HANDLE hSession,
+                                      CK_OBJECT_HANDLE hObject,
+                                      CK_ULONG ulOperationType,
+                                      CK_ULONG *pulFIPSStatus);
+
 #define NULL_PTR NULL
 
 /* Delete the helper macros defined at the top of the file.  */


### PR DESCRIPTION
Build is broken with libnss in version 3.66 and https://github.com/nss-dev/nss/commit/595deb8fbce65e931935fb7e22aea785cb6016ad because `CK_NSS_GetFIPSStatus` is undefined as `_pkcs11h-crypto-nss.c` is defining `_PKCS11T_H_`:

```
In file included from /home/buildroot/autobuild/instance-1/output-1/host/bin/../arc-buildroot-linux-gnu/sysroot/usr/include/nss/keythi.h:10,
                 from /home/buildroot/autobuild/instance-1/output-1/host/bin/../arc-buildroot-linux-gnu/sysroot/usr/include/nss/cert.h:21,
                 from _pkcs11h-crypto-nss.c:58:
/home/buildroot/autobuild/instance-1/output-1/host/bin/../arc-buildroot-linux-gnu/sysroot/usr/include/nss/secmodt.h:79:5: error: unknown type name 'CK_NSS_GetFIPSStatus'
   79 |     CK_NSS_GetFIPSStatus fipsIndicator;
      |     ^~~~~~~~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/1e8113d638fcb73538329511eeac9f5e7cb04d6a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>