### PR TITLE
nss: use nss pkcs11.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Copyright (c) 2005-2020 Alon Bar-Lev <alon.barlev@gmail.com>
 
 ????-??-?? - Version 1.28
 
+ * build: nss: use nss pkcs11.h, thanks to Fabrice Fontaine.
  * build: windows: checksum in PE, thanks to Simon Rozman.
  * build: windows: support openssl-1.1.1, thanks to Lev Stipakov.
  * mbed: require >=mbedtls-2, mbed dropped polarssl compatibility,

--- a/lib/_pkcs11h-crypto-nss.c
+++ b/lib/_pkcs11h-crypto-nss.c
@@ -48,14 +48,20 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#if defined(ENABLE_PKCS11H_ENGINE_NSS)
+#include <nss.h>
+#include <cert.h>
+
+/* Use PKCS#11 of nss to avoid conflicts and make nss happy with its own extensions */
+#define PKCS11_H 1
+
 #include "common.h"
 
 #include "_pkcs11h-crypto.h"
-
-#if defined(ENABLE_PKCS11H_ENGINE_NSS)
-#define _PKCS11T_H_ /* required so no conflict with ours */
-#include <nss.h>
-#include <cert.h>
 
 static
 int

--- a/lib/common.h
+++ b/lib/common.h
@@ -72,5 +72,12 @@
 
 #define _PKCS11H_ASSERT		assert
 
+#ifndef FALSE
+#define FALSE 0
+#endif
+#ifndef TRUE
+#define TRUE 1
+#endif
+
 #endif
 


### PR DESCRIPTION
make nss happy with its own extensions and non-standard behavior.