### PR TITLE
compatibility with openssl30

### DIFF
--- a/lib/pkcs11h-openssl.c
+++ b/lib/pkcs11h-openssl.c
@@ -474,9 +474,6 @@ __pkcs11h_openssl_rsa_dec (
 		case RSA_PKCS1_OAEP_PADDING:
 			mech = CKM_RSA_PKCS_OAEP;
 		break;
-		case RSA_SSLV23_PADDING:
-			rv = CKR_MECHANISM_INVALID;
-		break;
 		case RSA_NO_PADDING:
 			mech = CKM_RSA_X_509;
 		break;


### PR DESCRIPTION
this fix makes it compile with openssl30
consider case RSA_SSLV23_PADDING equals default