### PR TITLE
lib/pkcs11h-core.c: fix build without slotevent

### DIFF
--- a/lib/pkcs11h-core.c
+++ b/lib/pkcs11h-core.c
@@ -726,9 +726,11 @@ pkcs11h_setProperty (
 
 	switch (property) {
 		case PKCS11H_PROPERTY_SLOT_EVENT_HOOK:
+#if defined(ENABLE_PKCS11H_SLOTEVENT)
 			if ((rv = _pkcs11h_slotevent_init ()) != CKR_OK) {
 				goto cleanup;
 			}
+#endif
 		break;
 	}
 cleanup:


### PR DESCRIPTION
Fix the following build failure with `--disable-slotevent`:

```
/home/giuliobenetti/autobuild/run/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabihf/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabihf/bin/ld: /home/giuliobenetti/autobuild/run/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabihf/sysroot/usr/lib/libpkcs11-helper.so: undefined reference to `_pkcs11h_slotevent_init'
```

Fixes:
 - http://autobuild.buildroot.org/results/fcaa70cc035d6f9d35dfa8d564e9948c7e1cfd9e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>