### PR TITLE
fix build with libressl >= 3.5.0

### DIFF
--- a/lib/pkcs11h-openssl.c
+++ b/lib/pkcs11h-openssl.c
@@ -235,9 +235,13 @@ DSA_meth_free (DSA_METHOD *meth)
 static int
 DSA_meth_set1_name (DSA_METHOD *meth, const char *name)
 {
+#if (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x30500000L)
+	return 0;
+#else
 	CK_RV rv;
 	rv = _pkcs11h_mem_strdup ((void *)&meth->name, name);
 	return rv == CKR_OK ? 1 : 0;
+#endif
 }
 #endif
 


### PR DESCRIPTION
`DSA_METHOD` is opaque since libressl 3.5.0 and https://github.com/libressl-portable/openbsd/commit/62c7bff5397fa44f595b161cd593d9456eca236e resulting in the following build failure:

```
pkcs11h-openssl.c: In function 'DSA_meth_set1_name':
pkcs11h-openssl.c:239:41: error: invalid use of incomplete typedef 'DSA_METHOD' {aka 'struct dsa_method'}
  239 |  rv = _pkcs11h_mem_strdup ((void *)&meth->name, name);
      |                                         ^~
```

Fixes:
 - http://autobuild.buildroot.org/results/9b0d3bf7d97696c7be6de1724daaba196626b865

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>