### PR TITLE
Add provider property for dynamic loader flags

### DIFF
--- a/include/pkcs11-helper-1.0/pkcs11h-core.h
+++ b/include/pkcs11-helper-1.0/pkcs11h-core.h
@@ -384,8 +384,17 @@ extern "C" {
  */
 #define PKCS11H_PROVIDER_PROPERTY_PROVIDER_DESTRUCT_HOOK_DATA 8
 
+/**
+ * @brief Provider loader flags for platform.
+ * Value type is unsigned.
+ * Default value is platform dependent:
+ *     win32 -> 0
+ *    dlopen -> RTLD_NOW | RTLD_LOCAL
+ */
+#define PKCS11H_PROVIDER_PROPERTY_LOADER_FLAGS 9
+
 /** @private */
-#define _PKCS11H_PROVIDER_PROPERTY_LAST 9
+#define _PKCS11H_PROVIDER_PROPERTY_LAST 10
 
 /** @} */
 

--- a/lib/_pkcs11h-core.h
+++ b/lib/_pkcs11h-core.h
@@ -134,6 +134,8 @@ struct _pkcs11h_provider_s {
 #if defined(ENABLE_PKCS11H_SLOTEVENT)
 	_pkcs11h_thread_t slotevent_thread;
 #endif
+
+	unsigned loader_flags;
 };
 
 struct _pkcs11h_session_s {


### PR DESCRIPTION
In PE shared objects the search path can not be controlled by the loaded binary (in contrast to ELF).
Resolving additional dependencies provided by 3rd party DLLs in the same folder as the primary PKCS11 module.

This is required to avoid workarounds as needed for e.g. the default vendor-provided [YubiKey module](https://developers.yubico.com/yubico-piv-tool/YKCS11/).