### PR TITLE
Use URL encoding for binary values

### DIFF
--- a/lib/_pkcs11h-util.h
+++ b/lib/_pkcs11h-util.h
@@ -74,7 +74,8 @@ _pkcs11h_util_binaryToHex (
 	OUT char * const target,
 	IN const size_t target_size,
 	IN const unsigned char * const source,
-	IN const size_t source_size
+	IN const size_t source_size,
+	IN int url_escape
 );
 
 CK_RV
@@ -82,7 +83,8 @@ _pkcs11h_util_escapeString (
 	IN OUT char * const target,
 	IN const char * const source,
 	IN size_t * const max,
-	IN const char * const invalid_chars
+	IN const char * const invalid_chars,
+	IN int url_escape
 );
 
 CK_RV

--- a/lib/pkcs11h-serialization.c
+++ b/lib/pkcs11h-serialization.c
@@ -56,7 +56,9 @@
 #include "_pkcs11h-token.h"
 #include "_pkcs11h-certificate.h"
 
-#define __PKCS11H_SERIALIZE_INVALID_CHARS	"\\/\"'%&#@!?$* <>{}[]()`|:;,.+-"
+#define __PKCS11H_SERIALIZE_VALID_CHARS		"abcdefghijklmnopqrstuvwxyz" \
+                                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
+                                            "0123456789_-."
 
 #if defined(ENABLE_PKCS11H_TOKEN) || defined(ENABLE_PKCS11H_CERTIFICATE)
 
@@ -99,7 +101,7 @@ pkcs11h_token_serializeTokenId (
 				NULL,
 				sources[e],
 				&t,
-				__PKCS11H_SERIALIZE_INVALID_CHARS
+				__PKCS11H_SERIALIZE_VALID_CHARS
 			)) != CKR_OK
 		) {
 			goto cleanup;
@@ -121,7 +123,7 @@ pkcs11h_token_serializeTokenId (
 					sz+n,
 					sources[e],
 					&t,
-					__PKCS11H_SERIALIZE_INVALID_CHARS
+					__PKCS11H_SERIALIZE_VALID_CHARS
 				)) != CKR_OK
 			) {
 				goto cleanup;

--- a/lib/pkcs11h-serialization.c
+++ b/lib/pkcs11h-serialization.c
@@ -56,6 +56,7 @@
 #include "_pkcs11h-token.h"
 #include "_pkcs11h-certificate.h"
 
+#define __PKCS11H_SERIALIZE_AS_PKCS11_URI	1
 #define __PKCS11H_SERIALIZE_VALID_CHARS		"abcdefghijklmnopqrstuvwxyz" \
                                             "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
                                             "0123456789_-."
@@ -101,7 +102,8 @@ pkcs11h_token_serializeTokenId (
 				NULL,
 				sources[e],
 				&t,
-				__PKCS11H_SERIALIZE_VALID_CHARS
+				__PKCS11H_SERIALIZE_VALID_CHARS,
+				__PKCS11H_SERIALIZE_AS_PKCS11_URI	
 			)) != CKR_OK
 		) {
 			goto cleanup;
@@ -123,7 +125,8 @@ pkcs11h_token_serializeTokenId (
 					sz+n,
 					sources[e],
 					&t,
-					__PKCS11H_SERIALIZE_VALID_CHARS
+					__PKCS11H_SERIALIZE_VALID_CHARS,
+					__PKCS11H_SERIALIZE_AS_PKCS11_URI	
 				)) != CKR_OK
 			) {
 				goto cleanup;
@@ -327,7 +330,7 @@ pkcs11h_certificate_serializeCertificateId (
 		goto cleanup;
 	}
 
-	_max = n + certificate_id->attrCKA_ID_size*2 + 1;
+	_max = n + certificate_id->attrCKA_ID_size*3 + 1;
 
 	if (sz != NULL) {
 		if (saved_max < _max) {
@@ -336,12 +339,17 @@ pkcs11h_certificate_serializeCertificateId (
 		}
 
 		sz[n-1] = '/';
-		rv = _pkcs11h_util_binaryToHex (
-			sz+n,
-			saved_max-n,
-			certificate_id->attrCKA_ID,
-			certificate_id->attrCKA_ID_size
-		);
+		if (
+			(rv = _pkcs11h_util_binaryToHex (
+				sz+n,
+				saved_max-n,
+				certificate_id->attrCKA_ID,
+				certificate_id->attrCKA_ID_size,
+				__PKCS11H_SERIALIZE_AS_PKCS11_URI	
+			)) != CKR_OK
+		) {
+			goto cleanup;
+		}
 	}
 
 	*max = _max;

--- a/lib/pkcs11h-util.c
+++ b/lib/pkcs11h-util.c
@@ -148,7 +148,7 @@ _pkcs11h_util_escapeString (
 	IN OUT char * const target,
 	IN const char * const source,
 	IN size_t * const max,
-	IN const char * const invalid_chars
+	IN const char * const valid_chars
 ) {
 	static const char *x = "0123456789ABCDEF";
 	CK_RV rv = CKR_FUNCTION_FAILED;
@@ -162,7 +162,7 @@ _pkcs11h_util_escapeString (
 
 	while (*s != '\x0') {
 
-		if (*s == '\\' || strchr (invalid_chars, (unsigned char)*s) || !isgraph (*s)) {
+		if (!strchr (valid_chars, (unsigned char)*s)) {
 			if (t != NULL) {
 				if (n+4 > *max) {
 					rv = CKR_ATTRIBUTE_VALUE_INVALID;


### PR DESCRIPTION
If PKCS#11 URI format is desired, as proposed https://github.com/OpenSC/pkcs11-helper/pull/4, let's tell our binary serialization routines to accept and generate `%20` instead of `\x20`.