### PR TITLE
util: fix usage of ctype function

### DIFF
--- a/lib/pkcs11h-util.c
+++ b/lib/pkcs11h-util.c
@@ -179,7 +179,7 @@ _pkcs11h_util_escapeString (
 
 	while (*s != '\x0') {
 
-		if (*s == '\\' || strchr (invalid_chars, (unsigned char)*s) || !isgraph (*s)) {
+		if (*s == '\\' || strchr (invalid_chars, (unsigned char)*s) || !isgraph ((unsigned char)*s)) {
 			if (t != NULL) {
 				if (n+4 > *max) {
 					rv = CKR_ATTRIBUTE_VALUE_INVALID;


### PR DESCRIPTION
The argument of these functions is of type int, but only a very restricted subset of values are actually valid.  The argument must either be the value of the macro EOF (which has a negative value), or must be a non-negative value within the range representable as unsigned char. Passing invalid values leads to undefined behavior.