### PR TITLE
Fix build error with OpenSSL4

### DIFF
--- a/lib/_pkcs11h-crypto-openssl.c
+++ b/lib/_pkcs11h-crypto-openssl.c
@@ -148,21 +148,15 @@ __pkcs11h_crypto_openssl_certificate_get_expiration (
 		notBefore != NULL &&
 		notAfter != NULL &&
 		X509_cmp_current_time (notBefore) <= 0 &&
-		X509_cmp_current_time (notAfter) >= 0 &&
-		notAfter->length >= 12
+		X509_cmp_current_time (notAfter) >= 0
 	) {
 		struct tm tm1;
 
 		memset (&tm1, 0, sizeof (tm1));
-		tm1.tm_year = (notAfter->data[ 0] - '0') * 10 + (notAfter->data[ 1] - '0') + 100;
-		tm1.tm_mon  = (notAfter->data[ 2] - '0') * 10 + (notAfter->data[ 3] - '0') - 1;
-		tm1.tm_mday = (notAfter->data[ 4] - '0') * 10 + (notAfter->data[ 5] - '0');
-		tm1.tm_hour = (notAfter->data[ 6] - '0') * 10 + (notAfter->data[ 7] - '0');
-		tm1.tm_min  = (notAfter->data[ 8] - '0') * 10 + (notAfter->data[ 9] - '0');
-		tm1.tm_sec  = (notAfter->data[10] - '0') * 10 + (notAfter->data[11] - '0');
-
-		*expiration = mktime (&tm1);
-		*expiration += (int)(mktime (localtime (expiration)) - mktime (gmtime (expiration)));
+		if (ASN1_TIME_to_tm (notAfter, &tm1)) {
+			*expiration = mktime (&tm1);
+			*expiration += (int)(mktime (localtime (expiration)) - mktime (gmtime (expiration)));
+		}
 	}
 
 cleanup:


### PR DESCRIPTION
OpenSSL 4 no longer exposes the internal data and length fields of                                                                                                                       ASN1_TIME objects directly. Replace the manual byte-by-byte ASN1_TIME parsing                                                                                                           with the proper ASN1_TIME_to_tm() API. 